### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pinecone Model Context Protocol Server for Claude Desktop.
 
+[![smithery badge](https://smithery.ai/badge/mcp-pinecone)](https://smithery.ai/server/mcp-pinecone)
+
 Read and write to a Pinecone index.
 
 
@@ -84,6 +86,14 @@ The server implements the ability to read and write to a Pinecone index.
 
 Note: embeddings are generated via Pinecone's inference API and chunking is done with a rudimentary markdown splitter (via `langchain`).
 ## Quickstart
+
+### Installing via Smithery
+
+To install Pinecone MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/mcp-pinecone):
+
+```bash
+npx -y @smithery/cli install mcp-pinecone --client claude
+```
 
 ### Install the server
 


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install Pinecone MCP Server for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/mcp-pinecone

Let me know if any tweaks have to be made!